### PR TITLE
[fixed] PLATFORM_64 for arm64

### DIFF
--- a/MMOEngine/src/system/platform.h
+++ b/MMOEngine/src/system/platform.h
@@ -25,7 +25,7 @@
 	#define PLATFORM_UNIX
 #endif
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 #define PLATFORM_64
 #else
 #define PLATFORM_32


### PR DESCRIPTION
Performance of emulated x86-64 in Docker for M1 Macbooks is pretty slow. I wanted to run the emu code against Ubuntu arm64. This was the only compile error I ran into:
`/core3/MMOCoreORB/utils/engine3/MMOEngine/src/system/lang/types.h:227:9: error: cast from 'const engine::ORB::ObjectBroker*' to 'unsigned int' loses precision [-fpermissive]`

Which ultimately seems to be due to PLATFORM_64 not being defined.

Test:
Build and launched core3

Result:
Was able to launch server and log into the game and interact.