### PR TITLE
Added overload for float to string precision

### DIFF
--- a/MMOEngine/src/system/lang/String.cpp
+++ b/MMOEngine/src/system/lang/String.cpp
@@ -384,6 +384,16 @@ String String::valueOf(float val) {
 	return String(buf, written);
 }
 
+String String::valueOf(float val, int precision) {
+	char buf[40];
+
+	int written = snprintf(buf, 40, "%.*f", precision, val);
+
+	E3_ASSERT(written >= 0 && written < 40);
+
+	return String(buf, written);
+}
+
 String String::valueOf(double val) {
 	char buf[40];
 

--- a/MMOEngine/src/system/lang/String.h
+++ b/MMOEngine/src/system/lang/String.h
@@ -186,6 +186,7 @@ namespace sys {
 		static String valueOf(int64 val);
 		static String valueOf(uint64 val);
 		static String valueOf(float val);
+		static String valueOf(float val, int precision);
 		static String valueOf(double val);
 		static String valueOf(const void* val);
 		static String valueOf(const char* val);

--- a/MMOEngine/src/system/lang/StringBuffer.cpp
+++ b/MMOEngine/src/system/lang/StringBuffer.cpp
@@ -117,6 +117,14 @@ StringBuffer& StringBuffer::append(float val) {
 	return append(str);
 }
 
+StringBuffer& StringBuffer::append(float val, int places) {
+	String str;
+
+	str = String::valueOf(val, places);
+
+	return append(str);
+}
+
 StringBuffer& StringBuffer::append(double val) {
 	String str;
 

--- a/MMOEngine/src/system/lang/StringBuffer.h
+++ b/MMOEngine/src/system/lang/StringBuffer.h
@@ -56,6 +56,7 @@ namespace sys {
 		StringBuffer& append(int64 val);
 		StringBuffer& append(uint64 val);
 		StringBuffer& append(float val);
+		StringBuffer& append(float val, int places);
 		StringBuffer& append(double val);
 		StringBuffer& append(bool val);
 		StringBuffer& append(const void* val);


### PR DESCRIPTION
Adds an overload for float to string for JtL values - for fixing the POB mass showing as an exponent and to ensure there's always a trailing zero when appropriate.